### PR TITLE
fix the command line problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ setup(
     install_requires=[
         'simplejson'
         ],
-    entry_points="""
-            [console_scripts]
-            xml2json = xml2json:xml2json
-          """,
-    )
+    entry_points={
+        'console_scripts': [
+            'xml2json = xml2json:main'
+        ]
+    }
+)


### PR DESCRIPTION
Now we can install this from github directly and use it in command line. (I verified in windows platform)

```
$ pip install https://github.com/hay/xml2json/zipball/master
$ xml2json --help
```

Originally it reports:

```
$ xml2json
Traceback (most recent call last):
  File "c:\Python27\Scripts\xml2json-script.py", line 9, in <module>
    load_entry_point('xml2json==0.1', 'console_scripts', 'xml2json')()
TypeError: xml2json() takes at least 2 arguments (0 given)
```

Hope you can merge it ;-)
