### PR TITLE
Why were the attributes only set if strip_ns was not set?

### DIFF
--- a/xml2json.py
+++ b/xml2json.py
@@ -58,9 +58,8 @@ def elem_to_internal(elem, strip_ns=1, strip=1):
     elem_tag = elem.tag
     if strip_ns:
         elem_tag = strip_tag(elem.tag)
-    else:
-        for key, value in list(elem.attrib.items()):
-            d['@' + key] = value
+    for key, value in list(elem.attrib.items()):
+        d['@' + key] = value
 
     # loop over subelements to merge them
     for subelem in elem:


### PR DESCRIPTION
I had a document that came out basically empty if I set strip_ns ( the root element came through normally, but all child elements had no key or value in the built out dict() ).

I didn't understand that behavior, and it was not what i needed for my use case.  So, I removed the conditional around setting attributes. 

Not sure if this is the behavior as you want it to be..
