### PR TITLE
nosetests-3.4 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*pyc
+__pycache__/*

--- a/test/test_xml2json.py
+++ b/test/test_xml2json.py
@@ -1,6 +1,6 @@
 import unittest
 import xml2json
-import optparse 
+import optparse
 import json
 import os
 
@@ -10,38 +10,38 @@ options = None
 class SimplisticTest(unittest.TestCase):
 
     def setUp(self):
-    	global xmlstring, options
-    	filename = os.path.join(os.path.dirname(__file__), 'xml_ns2.xml')
-    	xmlstring = open(filename).read()
-    	options = optparse.Values({"pretty": False})
+        global xmlstring, options
+        filename = os.path.join(os.path.dirname(__file__), 'xml_ns2.xml')
+        xmlstring = open(filename).read()
+        options = optparse.Values({"pretty": False})
 
     def test_default_namespace_attribute(self):
-		strip_ns = 0
-		json_string = xml2json.xml2json(xmlstring,options,strip_ns)
-		# check string
-		self.assertTrue(json_string.find("{http://www.w3.org/TR/html4/}table") != -1)
-		self.assertTrue(json_string.find("{http://www.w3.org/TR/html4/}tr") != -1)
-		self.assertTrue(json_string.find("@class") != -1)
+        strip_ns = 0
+        json_string = xml2json.xml2json(xmlstring,options,strip_ns)
+        # check string
+        self.assertTrue(json_string.find("{http://www.w3.org/TR/html4/}table") != -1)
+        self.assertTrue(json_string.find("{http://www.w3.org/TR/html4/}tr") != -1)
+        self.assertTrue(json_string.find("@class") != -1)
 
-		# check the simple name is not exist
-		json_data = json.loads(json_string)
-		self.assertFalse("table" in json_data["root"])  	
+        # check the simple name is not exist
+        json_data = json.loads(json_string)
+        self.assertFalse("table" in json_data["root"])
 
     def test_strip_namespace(self):
-		strip_ns = 1    	
-		json_string = xml2json.xml2json(xmlstring,options,strip_ns)
-		json_data = json.loads(json_string)
+        strip_ns = 1
+        json_string = xml2json.xml2json(xmlstring,options,strip_ns)
+        json_data = json.loads(json_string)
 
-		# namespace is stripped
-		self.assertFalse(json_string.find("{http://www.w3.org/TR/html4/}table") != -1)
+        # namespace is stripped
+        self.assertFalse(json_string.find("{http://www.w3.org/TR/html4/}table") != -1)
 
-		# TODO , attribute shall be kept
-		#self.assertTrue(json_string.find("@class") != -1)
+        # TODO , attribute shall be kept
+        #self.assertTrue(json_string.find("@class") != -1)
 
-		#print json_data["root"]["table"]
-		#print json_data["root"]["table"][0]["tr"]
-		self.assertTrue("table" in json_data["root"])  			
-		self.assertEqual(json_data["root"]["table"][0]["tr"]["td"] , ["Apples", "Bananas"])
+        #print json_data["root"]["table"]
+        #print json_data["root"]["table"][0]["tr"]
+        self.assertTrue("table" in json_data["root"])
+        self.assertEqual(json_data["root"]["table"][0]["tr"]["td"] , ["Apples", "Bananas"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hello,

I've noticed, that nosetests-3.4 fails with:

```
$ nosetests-3.4 
E
======================================================================
ERROR: Failure: TabError (inconsistent use of tabs and spaces in indentation (test_xml2json.py, line 19))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
<snip>
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/home/msadowsk/Dropbox/xml2json/test/test_xml2json.py", line 19
    strip_ns = 0
               ^
TabError: inconsistent use of tabs and spaces in indentation

----------------------------------------------------------------------
Ran 1 test in 0.003s

FAILED (errors=1)
```

See my merge request which fixes this issue.