### PR TITLE
added ordered option for maintaining XML order in JSON

### DIFF
--- a/xml2json.py
+++ b/xml2json.py
@@ -67,7 +67,7 @@ def elem_to_internal(elem, strip_ns=1, strip=1, ordered=0):
 
     # loop over subelements to merge them
     for subelem in elem:
-        v = elem_to_internal(subelem, strip_ns=strip_ns, strip=strip)
+        v = elem_to_internal(subelem, strip_ns=strip_ns, strip=strip, ordered=ordered)
 
         tag = subelem.tag
         if strip_ns:


### PR DESCRIPTION
I had a requirement that the JSON maintained the same order as the original XML. To support this I added an ordered option. If this is specified I use an OrderedDict to maintain the order. If you like this enhancement, please merge it into the mainline branch. 
