### PR TITLE
Keeping attribute values when --strip_namespace set

### DIFF
--- a/xml2json.py
+++ b/xml2json.py
@@ -57,11 +57,11 @@ def elem_to_internal(elem, strip_ns=1, strip=1):
 
     d = OrderedDict()
     elem_tag = elem.tag
+
     if strip_ns:
         elem_tag = strip_tag(elem.tag)
-    else:
-        for key, value in list(elem.attrib.items()):
-            d['@' + key] = value
+    for key, value in list(elem.attrib.items()):
+        d['@' + key] = value
 
     # loop over subelements to merge them
     for subelem in elem:


### PR DESCRIPTION
Small change to keep attribute parameters when using the "--strip_namespace" option when exporting from xml to json.